### PR TITLE
refactor: remove deprecated test chain Chains.valid

### DIFF
--- a/src/main/kotlin/testing/Certs.kt
+++ b/src/main/kotlin/testing/Certs.kt
@@ -113,10 +113,6 @@ object CertLists {
 }
 
 object Chains {
-  @Deprecated("Use CertLists.validFactoryProvisioned instead")
-  @JvmStatic
-  val valid = KeyAttestationCertPath(CertLists.validFactoryProvisioned)
-
   @JvmStatic val validFactoryProvisioned = KeyAttestationCertPath(CertLists.validFactoryProvisioned)
 
   @JvmStatic


### PR DESCRIPTION
### Summary

This pull request removes the deprecated `Chains.valid` test chain from the test utility object.

### Context

The `Chains.valid` field is no longer referenced anywhere in the codebase.  
I verified this with `grep -r "Chains.valid"`, which confirmed there are no remaining usages:

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/01a6914c-388c-47a0-9bbb-656ced3adc47" />

### What’s Changed

- Removed the unused and deprecated `Chains.valid` field from the test chain definitions

### Why This Matters

Cleaning up deprecated and unused code improves maintainability and reduces confusion for future contributors exploring the test helpers.

---

Let me know if you'd like this change to be revised or scoped differently.
