### PR TITLE
Dependency cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   id("com.adarshr.test-logger") version "4.0.0"
-  id("com.google.devtools.ksp") version ("2.2.0-2.0.2")
   id("org.jetbrains.kotlin.jvm") version "2.2.0"
 }
 
@@ -25,7 +24,7 @@ repositories { mavenCentral() }
 dependencies {
   implementation("co.nstant.in:cbor:0.9")
   implementation("com.google.code.gson:gson:2.11.0")
-  implementation("com.google.guava:guava:33.3.1-android")
+  implementation("com.google.errorprone:error_prone_annotations:2.41.0")
   implementation("com.google.protobuf:protobuf-javalite:4.28.3")
   implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
   implementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.0")
@@ -66,7 +65,6 @@ val googleTrustAnchors by tasks.registering {
 
         import com.google.gson.Gson
         import java.security.cert.TrustAnchor
-        import org.bouncycastle.cert.X509CertificateHolder
 
         object GoogleTrustAnchors : () -> Set<TrustAnchor> {
           const val JSON = ""${'"'}


### PR DESCRIPTION
KSP no longer used since Moshi was removed, and the only part of guava that's actually used is the errorprone annotations.

`bcpkix` could be reduced to `bcprov` if the testing package weren't in the main sourceset but oh well