### PR TITLE
Fix README code examples + Extension.kt error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ when verifying. For example, if you expect the challenge to be equal to
 
 ```kotlin
 // Create a ChallengeChecker
-val challengeChecker = ChallengeMatcher("challenge123")
+val challengeChecker = ChallengeMatcher(ByteString.copyFromUtf8("challenge123"))
 
 // Verify an attestation certificate chain with the checker
 val result = verifier.verify(certificateChain, challengeChecker)
@@ -57,9 +57,14 @@ with an `InMemoryLruCache` like in this sample:
 ```kotlin
 val cacheSize = 100
 
-// Create a ChainedChallengeChecker with desired ChallengeCheckers
+// Create a ChainedChallengeChecker with desired ChallengeCheckers. The
+// coroutineScope is used to run each individual checker.
 val challengeChecker =
-  ChainedChallengeChecker.of(ChallengeMatcher("expectedChallenge"), InMemoryLruCache(cacheSize))
+  ChainedChallengeChecker.of(
+    coroutineScope,
+    ChallengeMatcher(ByteString.copyFromUtf8("expectedChallenge")),
+    InMemoryLruCache(cacheSize),
+  )
 
 // Verify an attestation certificate chain with the checker
 val result = verifier.verify(certificateChain, challengeChecker)

--- a/src/main/kotlin/Extension.kt
+++ b/src/main/kotlin/Extension.kt
@@ -536,7 +536,9 @@ data class PatchLevel(val yearMonth: YearMonth, val version: Int? = null) {
       partitionName: String = "",
       logFn: (String) -> Unit = { _ -> },
     ): PatchLevel? {
-      check(patchLevel is ASN1Integer) { "Must be an ASN1Integer, was ${this::class.simpleName}" }
+      check(patchLevel is ASN1Integer) {
+        "Must be an ASN1Integer, was ${patchLevel::class.simpleName}"
+      }
       return from(patchLevel.value.toString(), partitionName, logFn)
     }
 
@@ -768,7 +770,7 @@ private inline fun <reified T> ASN1Encodable.toSet(): Set<T> {
   return this.map {
       if (it !is T) {
         throw ExtensionParsingException(
-          "Object must be a ${T::class.simpleName}, was ${this::class.simpleName}"
+          "Object must be a ${T::class.simpleName}, was ${it::class.simpleName}"
         )
       }
       it


### PR DESCRIPTION
- README.md example code didn't compile: `ChallengeMatcher` has no `String` constructor, and `ChainedChallengeChecker.of` requires a `CoroutineScope` as the first argument.

- Extension.kt: `PatchLevel.from(ASN1Encodable)` used `this::class.simpleName` inside a `companion object`, which resolves to `"Companion"` instead of the offending value's runtime class.
- Extension.kt: `ASN1Encodable.toSet<T>()` element type-mismatch error reported the container's class instead of the offending element's class (`it::class.simpleName`).